### PR TITLE
Temporary remove gitlab.ccsd.cnrs.fr

### DIFF
--- a/platforms.csv
+++ b/platforms.csv
@@ -9,7 +9,6 @@ gitlab.com,gitlab
 gitlab.inria.fr,gitlab
 sourcesup.renater.fr,fusionforge
 gitlab.adullact.net,gitlab
-gitlab.ccsd.cnrs.fr,gitlab
 gitlab.irstea.fr,gitlab
 gitlab.ow2.org,gitlab
 forgemia.inra.fr,gitlab


### PR DESCRIPTION
Due to TLS issues on their side, as discussed by email