### PR TITLE
including subgroups projects in gitlab api call

### DIFF
--- a/gitlab.py
+++ b/gitlab.py
@@ -22,7 +22,7 @@ class GitLabOrg(object):
 
         data = []
 
-        url = f"{self.base_url}groups/{self.organisation}/projects?per_page=100"
+        url = f"{self.base_url}groups/{self.organisation}/projects?per_page=100&include_subgroups=true"
         response = requests.get(url)
         if response.status_code == 404:
             return {}


### PR DESCRIPTION
The fix is simple : simply add an API option from the [gitlab API](https://docs.gitlab.com/ee/api/groups.html#list-a-groups-projects) that tells the API to dig subgroups as well. It couldn't be cleaner :)